### PR TITLE
fix ^` in install.sh. it should be escaped

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -75,7 +75,7 @@ CopyFrom=Main
 .	.+	XLook $l0
 
 [Keybindings]
-control+`	Mark
+control+\`	Mark
 control+p	Savepos
 control+d	Tooltip Go describe
 control+b	Jump


### PR DESCRIPTION
this fix issue #1.  for me.

I tried to delete config file and re-install and this error show up /which I didn't notice in first time/
```
install yacco
./install.sh: line 29: bad substitution: no closing "`" in `    Mark
control+p       Savepos
control+d       Tooltip Go describe
control+b       Jump
control+.       |a+
control+,       |a-
```

then I fix it and re-install and everything works fine. 


I'm so sorry for all this noise that I make.