### PR TITLE
Quote EOF to prevent variable expansion

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,7 @@ function make_config {
 	mkdir -p $HOME/.config/yacco/
 	
 	if [ ! -e $HOME/.config/yacco/rc ]; then
-		cat >$HOME/.config/yacco/rc <<EOF
+		cat >$HOME/.config/yacco/rc <<'EOF'
 [Core]
 EnableHighlighting=true
 HideHidden=true


### PR DESCRIPTION
Hi,

first of all, thank you for your work!

After the installation (I installed yacco to a local folder, and added $INSTALLDIR/yaccodir to my $PATH) I had some trouble with the plumbing. I think that there is an (unwanted) variable expansion in the install script, so `$0` is being replaced with `./install.sh`. This PR quotes the `EOF` to prevent it.

Also, while we're here, I have a couple of question regarding the default config file:
 - sometimes `$0` is quoted, sometimes no, is it a typo or there is a reason?
 - [here](https://github.com/omar-polo/yacco/blob/de8e5cfa4d6b8cfac2b9ed2cc3fc70c6c4f3036a/install.sh#L74-L75) the argument to XLook is `$l0`. is it a special variable?

Again, thank you for your work, it's the best acme-clone I've managed to run so far, and I'm loving it!